### PR TITLE
多階層カテゴリの実装

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,9 +1,7 @@
 class HomeController < ApplicationController
-
   def index
     @items_category = Item.includes(:user).where(stock_status:"1",category_id:"1").order("created_at DESC")
     @items_brand = Item.includes(:user).where(stock_status:"1",brand_id:"1",).order("created_at DESC")
-    
+    @parent_categories = Category.where(ancestry: nil)
   end
-
-end
+end 

--- a/app/views/shared/_header.html.haml
+++ b/app/views/shared/_header.html.haml
@@ -16,49 +16,7 @@
           = link_to "カテゴリー", '#'
 
           %ul.header__navMenuSecond
-            %li.header__navContentSecond
-              = link_to "レディース", '#'
-
-              %ul.header__navMenuThird
-                %li.header__navContentThird
-                  = link_to "トップス", '#'
-
-                  %ul.header__navMenuForth
-                    %li.header__navContentForth
-                      = link_to "Tシャツ/カットソー(半袖/袖なし)"
-                    %li.header__navContentForth
-                      = link_to "Tシャツ/カットソー(七分/長袖)"
-
-                %li.header__navContentThird
-                  = link_to "ジャケット/アウター", '#'
-
-                  %ul.header__navMenuForth
-                    %li.header__navContentForth
-                      = link_to "テーラードジャケット", '#'
-                    %li.header__navContentForth
-                      = link_to "ノーカラージャケット", '#'
-
-            %li.header__navContentSecond
-              = link_to "メンズ", '#'
-
-              %ul.header__navMenuThird
-                %li.header__navContentThird
-                  = link_to "トップス", '#'
-
-                  %ul.header__navMenuForth
-                    %li.header__navContentForth
-                      = link_to "Tシャツ/カットソー(半袖/袖なし)"
-                    %li.header__navContentForth
-                      = link_to "Tシャツ/カットソー(七分/長袖)", '#'
-
-                %li.header__navContentThird
-                  = link_to "ジャケット/アウター", '#'
-
-                  %ul.header__navMenuForth
-                    %li.header__navContentForth
-                      = link_to "テーラードジャケット", '#'
-                    %li.header__navContentForth
-                      = link_to "ノーカラージャケット", '#'
+            = render partial: "shared/navMenu_second", collection: @parent_categories, as: "parent_category"
 
         %li.header__navContent
           = link_to "ブランド", '#'

--- a/app/views/shared/_navMenu_forth.html.haml
+++ b/app/views/shared/_navMenu_forth.html.haml
@@ -1,0 +1,2 @@
+%li.header__navContentForth
+  = link_to "#{grandchild_category.name}", '#'

--- a/app/views/shared/_navMenu_second.html.haml
+++ b/app/views/shared/_navMenu_second.html.haml
@@ -1,0 +1,4 @@
+%li.header__navContentSecond
+  = link_to "#{parent_category.name}", '#'
+  %ul.header__navMenuThird
+    = render partial: "shared/navMenu_third", collection: parent_category.children, as: "child_category"

--- a/app/views/shared/_navMenu_third.html.haml
+++ b/app/views/shared/_navMenu_third.html.haml
@@ -1,0 +1,4 @@
+%li.header__navContentThird
+  = link_to "#{child_category.name}", '#'
+  %ul.header__navMenuForth
+    = render partial: "shared/navMenu_forth", collection: child_category.children, as: "grandchild_category"


### PR DESCRIPTION
# what
・多階層カテゴリ管理のためancestryを導入
（他のブランチですでに導入済）
・categoriesテーブルのサンプルデータを作成
（他のブランチですでに作成済）
・トップページ、ヘッダーのプルダウンにDBから読み込んだカテゴリを表示
　ただしカテゴリを押した時のリンクは未実装

# why
カテゴリに子孫関係を作るため
必須実装

![60124c606dbba5c475ccfa13fd12480b](https://user-images.githubusercontent.com/55943677/75025702-006ff980-54df-11ea-9619-12907504f595.gif)


